### PR TITLE
Unskip tests for json-guard

### DIFF
--- a/tests/src/PHPUnit/BenchmarkDraft4/Draft4LeagueJsonGuardTest.php
+++ b/tests/src/PHPUnit/BenchmarkDraft4/Draft4LeagueJsonGuardTest.php
@@ -51,14 +51,7 @@ class Draft4LeagueJsonGuardTest extends Draft4Test
 
     protected function skipTest($name)
     {
-        static $skip = array(
-            // PHP Fatal error:  Maximum function nesting level of '256' reached, aborting!
-            'refRemote.json root ref in remote ref: string is valid [0]' => true,
-
-            // PHP Fatal error:  Maximum function nesting level of '256' reached, aborting!
-            'refRemote.json root ref in remote ref: object is invalid [2]' => true,
-        );
-        return isset($skip[$name]);
+        return false;
     }
 
 


### PR DESCRIPTION
These tests pass in the json-guard test suite so it shouldn't be necessary to skip them.  The comment indicates the tests were failing because they were run with xdebug, but xdebug is disabled on Travis so it shouldn't be necessary.