### PR TITLE
Fixed opis test classes

### DIFF
--- a/tests/src/PHPUnit/BenchmarkDraft7/Draft7OpisTest.php
+++ b/tests/src/PHPUnit/BenchmarkDraft7/Draft7OpisTest.php
@@ -2,6 +2,7 @@
 
 namespace Swaggest\JsonSchemaBench\Tests\PHPUnit\BenchmarkDraft7;
 
+use Opis\JsonSchema\Exception\AbstractSchemaException;
 use Opis\JsonSchema\Loaders\Memory;
 use Opis\JsonSchema\Schema;
 use Opis\JsonSchema\Validator;
@@ -47,17 +48,11 @@ class Draft7OpisTest extends Draft7Test
         return $schemaStorage;
     }
 
-    /** @var \SplObjectStorage */
-    private $schemasCache;
+    /** @var Schema */
+    private $schemaCache;
 
     /** @var Validator */
-    private $validator;
-
-    protected function setUp()
-    {
-        $this->schemasCache = new \SplObjectStorage();
-        $this->validator = new Validator(null, self::getLoader());
-    }
+    private $validator = null;
 
     /**
      * @param $schemaData
@@ -69,19 +64,22 @@ class Draft7OpisTest extends Draft7Test
      */
     protected function runSpecTest($schemaData, $data, $isValid, $name, $version)
     {
-        if (false && is_object($schemaData)) {
-            if ($this->schemasCache->contains($schemaData)) {
-                $schema = $this->schemasCache->offsetGet($schemaData);
-            } else {
-                $schema = new Schema($schemaData);
-                $this->schemasCache->attach($schemaData, $schema);
-            }
-        } else {
-            $schema = new Schema($schemaData);
-        }
-        $result = $this->validator->schemaValidation($data, $schema);
+        if ($this->validator === null) {
+            $this->validator = (new Validator())
+                ->varsSupport(false)
+                ->filtersSupport(false)
+                ->mapSupport(false)
+                ->setLoader(self::getLoader());
 
-        $actualValid = $result->isValid();
+            $this->schemaCache = new Schema($schemaData);
+        }
+
+        try {
+            $actualValid = $this->validator->schemaValidation($data, $this->schemaCache)->isValid();
+        }
+        catch (AbstractSchemaException $e) {
+            $actualValid = false;
+        }
 
         $this->assertSame($isValid, $actualValid, "Test: $name");
     }


### PR DESCRIPTION
I've changed the test classes for opis to be a fair benchmark. Swaggest uses schema cache, so I've added the same thing to opis (cache is automatically wiped by phpunit for every test, it only persists for those 500 iterations).

Also, I've disabled the custom keyword support for opis.

This PR doesn't contain the reports, only the code changes, so please re-run the benchmarks and update the reports.

Thank you!

LE: currently used opis/json-schema version for benchmark is 1.0.4, but the latest is 1.0.9